### PR TITLE
Fix libxmljs require by using prebuilt's nativeRequire

### DIFF
--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,1 +1,3 @@
-module.exports = require('bindings')('xmljs');
+var path = require('path');
+exports = module.exports = require('prebuilt').
+	requireNative(path.join(__dirname, '..'), "xmljs");


### PR DESCRIPTION
Fix libxmljs require by using prebuilt's nativeRequire
